### PR TITLE
Cleanup suggestion: remove `__using__/2`s synonymous with `import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fully-curried 0-arity functions.
 ```elixir
 
 defmodule Foo do
-  use Quark.Curry
+  import Quark.Curry
 
   defcurry div(a, b), do: a / b
   defcurryp minus(a, b), do: a - b
@@ -144,7 +144,7 @@ Provides a clean, composable named functions. Also doubles as an aliasing device
 
 ```elixir
 defmodule Contrived do
-  use Quark.Pointfree
+  import Quark.Pointfree
   defx sum_plus_one, do: Enum.sum() |> fn x -> x + 1 end.()
 end
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This does use up the full arity-space for that function name, however.
 ```elixir
 
 defmodule Foo do
-  use Quark.Partial
+  import Quark.Partial
 
   defpartial one(), do: 1
   defpartial minus(a, b, c), do: a - b - c

--- a/lib/quark.ex
+++ b/lib/quark.ex
@@ -11,7 +11,7 @@ defmodule Quark do
     quote do
       import unquote(__MODULE__)
       import Quark.Curry
-      use Quark.Partial
+      import Quark.Partial
       import Quark.Pointfree
     end
   end

--- a/lib/quark.ex
+++ b/lib/quark.ex
@@ -10,9 +10,9 @@ defmodule Quark do
   defmacro __using__(_) do
     quote do
       import unquote(__MODULE__)
-      use Quark.Curry
+      import Quark.Curry
       use Quark.Partial
-      use Quark.Pointfree
+      import Quark.Pointfree
     end
   end
 

--- a/lib/quark/bckw.ex
+++ b/lib/quark/bckw.ex
@@ -4,7 +4,7 @@ defmodule Quark.BCKW do
   A similar idea to `SKI`, but with different primitives.
   """
 
-  use Quark.Partial
+  import Quark.Partial
   import Quark.Curry, only: [curry: 1]
 
   @doc ~S"""

--- a/lib/quark/compose.ex
+++ b/lib/quark/compose.ex
@@ -19,7 +19,7 @@ defmodule Quark.Compose do
   import Quark.SKI
 
   use Quark.Partial
-  use Quark.Curry
+  import Quark.Curry
 
   @doc ~S"""
   Function composition

--- a/lib/quark/compose.ex
+++ b/lib/quark/compose.ex
@@ -18,7 +18,7 @@ defmodule Quark.Compose do
 
   import Quark.SKI
 
-  use Quark.Partial
+  import Quark.Partial
   import Quark.Curry
 
   @doc ~S"""

--- a/lib/quark/curry.ex
+++ b/lib/quark/curry.ex
@@ -6,13 +6,6 @@ defmodule Quark.Curry do
   partial application on any curried function.
   """
 
-  defmacro __using__(_) do
-    quote do
-      require unquote(__MODULE__)
-      import unquote(__MODULE__)
-    end
-  end
-
   @doc ~S"""
   Curry a function at runtime, rather than upon definition
 

--- a/lib/quark/curry.ex
+++ b/lib/quark/curry.ex
@@ -107,5 +107,5 @@ defmodule Quark.Curry do
     end
   end
 
-  defp wrap(_, body), do: body
+  defp wrap([], body), do: body
 end

--- a/lib/quark/fixed_point.ex
+++ b/lib/quark/fixed_point.ex
@@ -26,7 +26,7 @@ defmodule Quark.FixedPoint do
 
   """
 
-  use Quark.Partial
+  import Quark.Partial
   import Quark.Curry, only: [curry: 1]
 
   defdelegate fix(),  to: __MODULE__, as: :y

--- a/lib/quark/m.ex
+++ b/lib/quark/m.ex
@@ -1,7 +1,7 @@
 defmodule Quark.M do
   @moduledoc "The self-applyication combinator"
 
-  use Quark.Partial
+  import Quark.Partial
 
   @doc ~S"""
   Apply a function to itself. Also aliased as `self_apply`.

--- a/lib/quark/partial.ex
+++ b/lib/quark/partial.ex
@@ -15,8 +15,7 @@ defmodule Quark.Partial do
   function, fall back to `defcurry` and partially apply manually.
   """
 
-  use Quark.Curry
-  require Quark.Curry
+  import Quark.Curry
 
   defmacro __using__(_) do
     quote do

--- a/lib/quark/partial.ex
+++ b/lib/quark/partial.ex
@@ -17,12 +17,6 @@ defmodule Quark.Partial do
 
   import Quark.Curry
 
-  defmacro __using__(_) do
-    quote do
-      import Quark.Partial, only: [defpartial: 2, defpartialp: 2]
-    end
-  end
-
   @doc ~S"""
   A convenience on `defcurry`. Generates a series of partially-bound
   applications of a fully-curried function, for all arities _at and below_

--- a/lib/quark/pointfree.ex
+++ b/lib/quark/pointfree.ex
@@ -6,27 +6,20 @@ defmodule Quark.Pointfree do
   Provides a clean, composable named functions
   """
 
-  defmacro __using__(_) do
-    quote do
-      require unquote(__MODULE__)
-      import unquote(__MODULE__)
-    end
-  end
-
   @doc ~S"""
   Define a unary function with an implied subject
 
   ## Examples
 
       iex> defmodule Foo do
-      ...>   use Quark.Pointfree
+      ...>   import Quark.Pointfree
       ...>   defx foo(), do: Enum.sum |> fn x -> x + 1 end.()
       ...> end
       ...> Foo.foo([1,2,3])
       7
 
       iex> defmodule Bar do
-      ...>   use Quark.Pointfree
+      ...>   import Quark.Pointfree
       ...>   defx bar, do: Enum.sum |> fn x -> x + 1 end.()
       ...> end
       ...> Bar.bar([1,2,3])
@@ -49,7 +42,7 @@ defmodule Quark.Pointfree do
   ## Examples
 
       defmodule Foo do
-        use Quark.Pointfree
+        import Quark.Pointfree
         defxp foo(), do: Enum.sum |> fn x -> x + 1 end.()
       end
 

--- a/lib/quark/ski.ex
+++ b/lib/quark/ski.ex
@@ -5,7 +5,7 @@ defmodule Quark.SKI do
   though generally not efficiently.
   """
 
-  use Quark.Partial
+  import Quark.Partial
 
   @doc ~S"""
   The identity combinator. Also aliased as `id`.

--- a/test/quark/curry_test.exs
+++ b/test/quark/curry_test.exs
@@ -1,6 +1,6 @@
 defmodule Quark.CurryTest do
   use ExUnit.Case, async: true
-  use Quark.Curry
+  import Quark.Curry
 
   defcurry div(a, b), do: a / b
   defcurryp minus(a, b), do: a - b

--- a/test/quark/partial_test.exs
+++ b/test/quark/partial_test.exs
@@ -1,6 +1,6 @@
 defmodule Quark.PartialTest do
   use ExUnit.Case, async: true
-  use Quark.Partial
+  import Quark.Partial
 
   defpartial one(), do: 1
   test "creates zero arity functions" do


### PR DESCRIPTION
This would probably be a breaking change for anyone using Quark directly, but as far as I can tell TypeClass, Witchcraft and Algae simply `use Quark`.

Thank you!

```text
0 [10:39:43] date; mix test
Thu Feb 28 10:39:51 PST 2019
warning: found quoted keyword "quality" but the quotes are not required. Note that keywords are always atoms, even when quoted, and q
uotes should only be used to introduce keywords with foreign characters in them
  mix.exs:23

.........................................................

Finished in 0.3 seconds
46 doctests, 11 tests, 0 failures

Randomized with seed 228963
```

(EDIT: Basically all changes are along the lines of https://github.com/expede/type_class/issues/1)