### PR TITLE
Indentation fix for documentation

### DIFF
--- a/lib/quark/compose.ex
+++ b/lib/quark/compose.ex
@@ -138,9 +138,9 @@ defmodule Quark.Compose do
 
   ## Examples
 
-  iex> sum_plus_one = compose_list([&(&1 + 1), &Enum.sum/1])
-  ...> sum_plus_one.([1, 2, 3])
-  7
+      iex> sum_plus_one = compose_list([&(&1 + 1), &Enum.sum/1])
+      ...> sum_plus_one.([1, 2, 3])
+      7
 
   """
   @spec compose_list([fun]) :: fun

--- a/lib/quark/compose.ex
+++ b/lib/quark/compose.ex
@@ -73,7 +73,7 @@ defmodule Quark.Compose do
   def g <|> f, do: compose(g, f)
 
   @doc ~S"""
-  Function composition, from the back of the list to the front
+  Function composition, from the head to tail (left-to-right)
 
   ## Examples
 
@@ -115,9 +115,7 @@ defmodule Quark.Compose do
   def f <~> g, do: compose_forward(f, g)
 
   @doc ~S"""
-  Compose functions, from the head of the list of functions. The is the reverse
-  order versus what one would normally expect (left-to-right rather than
-  right-to-left).
+  Compose functions, from the head of the list of functions.
 
   ## Examples
 
@@ -132,9 +130,9 @@ defmodule Quark.Compose do
   end
 
   @doc ~S"""
-  Compose functions, from the head of the list of functions. The is the reverse
-  order versus what one would normally expect (left-to-right rather than
-  right-to-left).
+  Compose functions, from the tail of the list of functions. This is the reverse
+  order versus what one would normally expect (right-to-left, rather than
+  left-to-right).
 
   ## Examples
 


### PR DESCRIPTION
While reading the documentation I noticed `compose_list/1` was not properly formatted for its `## Examples` section, and... this fixes that.

**Edit**

[1] I also made a few corrections to the documentation's wording where it was wrong (probably from some of that good ol' copypasta).

[2] I'm not sure why CI is failing, it looks like it can't find the archive to even run...