### PR TITLE
Fix uncurry(fun, args_list)

### DIFF
--- a/lib/quark/curry.ex
+++ b/lib/quark/curry.ex
@@ -73,7 +73,7 @@ defmodule Quark.Curry do
   @spec uncurry(fun, any | [any]) :: any
   def uncurry(fun, arg_list) when is_list(arg_list) do
     arg_list
-    |> Enum.reduce(fun, &Kernel.apply/2)
+    |> Enum.reduce(fun, fn arg, fun -> fun.(arg) end)
   end
   def uncurry(fun, arg), do: fun.(arg)
 

--- a/lib/quark/curry.ex
+++ b/lib/quark/curry.ex
@@ -56,14 +56,6 @@ defmodule Quark.Curry do
       ...> uncurry(curried_add, [1,2])
       3
 
-  """
-  @spec uncurry(fun, any | [any]) :: any
-  def uncurry(fun, arg_list) when is_list(arg_list) do
-    arg_list
-    |> Enum.reduce(fun, &Kernel.apply/2)
-  end
-
-  @doc ~S"""
   Apply an argument to a function
 
   ## Examples
@@ -78,7 +70,11 @@ defmodule Quark.Curry do
       4
 
   """
-  @spec uncurry(fun, any) :: any
+  @spec uncurry(fun, any | [any]) :: any
+  def uncurry(fun, arg_list) when is_list(arg_list) do
+    arg_list
+    |> Enum.reduce(fun, &Kernel.apply/2)
+  end
   def uncurry(fun, arg), do: fun.(arg)
 
   @doc "Define a curried function"


### PR DESCRIPTION
Doctest for first implementation of `uncurry` hasn't been running so that bugs were hidden.