### PR TITLE
Defpartial for zero arity

### DIFF
--- a/lib/quark/curry.ex
+++ b/lib/quark/curry.ex
@@ -100,4 +100,5 @@ defmodule Quark.Curry do
   end
 
   defp wrap([], body), do: body
+  defp wrap(nil, body), do: body
 end

--- a/lib/quark/partial.ex
+++ b/lib/quark/partial.ex
@@ -48,7 +48,11 @@ defmodule Quark.Partial do
       #=> 3
 
   """
-  defmacro defpartial({fun_name, ctx, args}, do: body) do
+  defmacro defpartial({fun_name, ctx, nil}, do: body), do: defpartial_quote({fun_name, ctx, []}, do: body)
+
+  defmacro defpartial({fun_name, ctx, args}, do: body), do: defpartial_quote({fun_name, ctx, args}, do: body)
+
+  defp defpartial_quote({fun_name, ctx, args}, do: body) do
     quote do
       defcurry unquote({fun_name, ctx, args}), do: unquote(body)
       unquote do: Enum.map(args_scan(args), &rehydrate(fun_name, ctx, &1))

--- a/test/quark/curry_test.exs
+++ b/test/quark/curry_test.exs
@@ -22,4 +22,12 @@ defmodule Quark.CurryTest do
     below10 = minus().(10)
     assert below10.(9) == 1
   end
+
+  defcurry one(), do: 1
+  defcurry two, do: 2
+
+  test "supports zero arity" do
+    assert one() == 1
+    assert two == 2
+  end
 end

--- a/test/quark/partial_test.exs
+++ b/test/quark/partial_test.exs
@@ -3,8 +3,10 @@ defmodule Quark.PartialTest do
   import Quark.Partial
 
   defpartial one(), do: 1
+  defpartial two, do: 2
   test "creates zero arity functions" do
     assert one() == 1
+    assert two() == 2
   end
 
   defpartial minus(a, b, c), do: a - b - c


### PR DESCRIPTION
## Summary

This PR fixes a compilation error, when `defcurry` or `defpartial` are declared as zero-arity functions without parentheses: `defcurry f, do: 1` and `defpartial f, do: 1` respectively.

## Test plan (required)

Corresponding tests are implemented and passing

## Closing issues

Fixes #45

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [x] Does this change require a release to be made? Is so please create and deploy the release
